### PR TITLE
Fix HipPrintf pass crashes on an invalid specifier

### DIFF
--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -96,3 +96,4 @@ add_hipcc_test(TestZeroLenArrayTypes.hip TEST_NAME TestZeroLenArrayTypes-O0
   HIPCC_OPTIONS -O0 -c)
 add_hipcc_test(TestZeroLenArrayTypes.hip TEST_NAME TestZeroLenArrayTypes-O1
   HIPCC_OPTIONS -O1 -c)
+add_hipcc_test(TestPrintfLonePercent.hip HIPCC_OPTIONS -c)

--- a/tests/compiler/TestPrintfLonePercent.hip
+++ b/tests/compiler/TestPrintfLonePercent.hip
@@ -1,0 +1,6 @@
+// Regression test for https://github.com/CHIP-SPV/chip-spv/issues/391
+#include <hip/hip_runtime.h>
+// NOTE: This format string has an invalid specifier which triggers
+// undefined behavior. The goal with this test is to check the
+// compiler does not crash.
+__global__ void k() { printf("%\n"); }


### PR DESCRIPTION
The format string described in #391 has an invalid specifier which triggers undefined behavior. However, The compiler should not crash in such case.

Fixes #391.