### PR TITLE
Fix #211 and others

### DIFF
--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -1740,7 +1740,12 @@ void CHIPQueue::launch(CHIPExecItem *ExecItem) {
   InfoStr << "NumArgs: " << FuncInfo.getNumKernelArgs() << "\n";
   auto Visitor = [&](const SPVFuncInfo::KernelArg &Arg) -> void {
     InfoStr << "Arg " << Arg.Index << ": " << Arg.getKindAsString() << " "
-            << Arg.Size << " " << Arg.Data << "\n";
+            << Arg.Size << " " << Arg.Data;
+    if (Arg.Kind == SPVTypeKind::Pointer && !Arg.isWorkgroupPtr()) {
+      void *PtrVal = *static_cast<void **>(const_cast<void *>(Arg.Data));
+      InfoStr << " (" << PtrVal << ")";
+    }
+    InfoStr << "\n";
   };
   FuncInfo.visitKernelArgs(ExecItem->getArgs(), Visitor);
 

--- a/src/CHIPBackend.cc
+++ b/src/CHIPBackend.cc
@@ -505,7 +505,6 @@ CHIPExecItem::CHIPExecItem(dim3 GridDim, dim3 BlockDim, size_t SharedMem,
 
 dim3 CHIPExecItem::getBlock() { return BlockDim_; }
 dim3 CHIPExecItem::getGrid() { return GridDim_; }
-CHIPKernel *CHIPExecItem::getKernel() { return ChipKernel_; }
 size_t CHIPExecItem::getSharedMem() { return SharedMem_; }
 CHIPQueue *CHIPExecItem::getQueue() { return ChipQueue_; }
 // CHIPDevice

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1578,7 +1578,7 @@ protected:
 
 public:
   std::vector<CHIPEvent *> Events;
-  std::mutex ContextMtx;
+  mutable std::mutex ContextMtx;
 
   /**
    * @brief Destroy the CHIPContext object
@@ -2014,8 +2014,8 @@ public:
     HOST_READ,
     HOST_WRITE,
   };
-  virtual void MemMap(AllocationInfo *AllocInfo, MEM_MAP_TYPE MapType) {}
-  virtual void MemUnmap(AllocationInfo *AllocInfo) {}
+  virtual void MemMap(const AllocationInfo *AllocInfo, MEM_MAP_TYPE MapType) {}
+  virtual void MemUnmap(const AllocationInfo *AllocInfo) {}
 
   /**
    * @brief Check the stream to see if it's in capture mode and if so, capture.

--- a/src/CHIPBackend.hh
+++ b/src/CHIPBackend.hh
@@ -1090,7 +1090,6 @@ protected:
   dim3 GridDim_;
   dim3 BlockDim_;
 
-  CHIPKernel *ChipKernel_;
   CHIPQueue *ChipQueue_;
 
   std::vector<void *> Args_;
@@ -1147,16 +1146,25 @@ public:
                hipStream_t ChipQueue);
 
   /**
+   * @brief Set the Kernel object
+   *
+   * @return CHIPKernel* Kernel to be executed
+   */
+  virtual void setKernel(CHIPKernel *Kernel) = 0;
+
+  /**
    * @brief Get the Kernel object
    *
    * @return CHIPKernel* Kernel to be executed
    */
-  CHIPKernel *getKernel();
+  virtual CHIPKernel *getKernel() = 0;
+
   /**
    * @brief Get the Queue object
    *
    * @return CHIPQueue*
    */
+
   CHIPQueue *getQueue();
 
   /**
@@ -1188,8 +1196,6 @@ public:
    *
    */
   virtual void setupAllArgs() = 0;
-
-  void setKernel(CHIPKernel *Kernel) { this->ChipKernel_ = Kernel; }
 
   std::shared_ptr<CHIPArgSpillBuffer> getArgSpillBuffer() const {
     return ArgSpillBuffer_;

--- a/src/CHIPBindings.cc
+++ b/src/CHIPBindings.cc
@@ -2246,11 +2246,6 @@ hipError_t hipMalloc(void **Ptr, size_t Size) {
   *Ptr = RetVal;
   logInfo("hipMalloc(ptr={}, size={})", (void *)RetVal, Size);
 
-  // currently required by both OpenCL and Level Zero when passing in SoA
-  bool firstTouch;
-  auto Status = Backend->getActiveDevice()->getDefaultQueue()->memCopy(
-      RetVal, &firstTouch, 1);
-  assert(Status == hipSuccess);
   RETURN(hipSuccess);
 
   CHIP_CATCH

--- a/src/Utils.hh
+++ b/src/Utils.hh
@@ -126,8 +126,7 @@ template <class T> struct PointerCmp {
     Helper() : Ptr(nullptr) {}
     Helper(Helper const &) = default;
     Helper(T *p) : Ptr(p) {}
-    // template <class U, class... Ts>
-    // Helper(std::shared_ptr<U, Ts...> const &Sp) : Ptr(Sp.get()) {}
+    template <class U> Helper(std::shared_ptr<U> const &Sp) : Ptr(Sp.get()) {}
     template <class U, class... Ts>
     Helper(std::unique_ptr<U, Ts...> const &Up) : Ptr(Up.get()) {}
     // && optional: enforces rvalue use only

--- a/src/Utils.hh
+++ b/src/Utils.hh
@@ -103,6 +103,18 @@ public:
   bool empty() const { return Begin_ == End_; }
 };
 
+/// An iterator adaptor for map-like containers for iterating its keys only.
+template <typename MapT>
+class ConstMapKeyIterator : public MapT::const_iterator {
+public:
+  ConstMapKeyIterator(typename MapT::const_iterator It)
+      : MapT::const_iterator(std::move(It)) {}
+
+  const typename MapT::key_type &operator*() const {
+    return MapT::const_iterator::operator*().first;
+  }
+};
+
 // A less comparator for comparing mixed raw and smart pointers.
 //
 // From https://stackoverflow.com/questions/18939882. Formatted for

--- a/src/backend/Level0/CHIPBackendLevel0.cc
+++ b/src/backend/Level0/CHIPBackendLevel0.cc
@@ -2378,3 +2378,9 @@ void CHIPExecItemLevel0::setupAllArgs() {
 
   return;
 }
+
+void CHIPExecItemLevel0::setKernel(CHIPKernel *Kernel) {
+  ChipKernel_ = static_cast<CHIPKernelLevel0 *>(Kernel);
+}
+
+CHIPKernel *CHIPExecItemLevel0::getKernel() { return ChipKernel_; }

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -505,6 +505,9 @@ public:
                                  int NumHandles) override;
 
   ze_device_properties_t *getDeviceProps() { return &(this->ZeDeviceProps_); };
+  bool hasOnDemandPaging() const {
+    return (ZeDeviceProps_.flags & ZE_DEVICE_PROPERTY_FLAG_ONDEMANDPAGING);
+  }
 
   ze_image_handle_t allocateImage(unsigned int TextureType,
                                   hipChannelFormatDesc Format,

--- a/src/backend/Level0/CHIPBackendLevel0.hh
+++ b/src/backend/Level0/CHIPBackendLevel0.hh
@@ -44,8 +44,11 @@ class CHIPQueueLevel0;
 class LZCommandList;
 class LZEventPool;
 class CHIPExecItemLevel0;
+class CHIPKernelLevel0;
 
 class CHIPExecItemLevel0 : public CHIPExecItem {
+  CHIPKernelLevel0 *ChipKernel_ = nullptr;
+
 public:
   CHIPExecItemLevel0(const CHIPExecItemLevel0 &Other)
       : CHIPExecItemLevel0(Other.GridDim_, Other.BlockDim_, Other.SharedMem_,
@@ -66,6 +69,9 @@ public:
     auto NewExecItem = new CHIPExecItemLevel0(*this);
     return NewExecItem;
   }
+
+  void setKernel(CHIPKernel *Kernel) override;
+  CHIPKernel *getKernel() override;
 };
 
 class CHIPEventLevel0 : public CHIPEvent {

--- a/src/backend/OpenCL/CHIPBackendOpenCL.cc
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.cc
@@ -214,10 +214,55 @@ static void memCopyToImage(cl_command_queue CmdQ, cl_mem Image,
   CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS, hipErrorTbd);
 }
 
-static void CL_CALLBACK releaseSpillBufferCallback(cl_event Event,
-                                                   cl_int CommandExecStatus,
-                                                   void *UserData) {
-  delete reinterpret_cast<std::shared_ptr<CHIPArgSpillBuffer> *>(UserData);
+/// Annotate SVM pointers to the OpenCL driver via clSetKernelExecInfo
+///
+/// This is needed for HIP applications which pass allocations
+/// indirectly to kernels (e.g. within an aggregate kernel argument or
+/// within another allocation). Without the annotation the allocations
+/// may not be properly synchronized.
+///
+/// Returns the list of annotated pointers.
+static std::unique_ptr<std::vector<std::shared_ptr<void>>>
+annotateSvmPointers(const CHIPContextOpenCL &Ctx, cl_kernel KernelAPIHandle) {
+  // By default we pass every allocated SVM pointer at this point to
+  // the clSetKernelExecInfo() since any of them could be potentially
+  // be accessed indirectly by the kernel.
+  //
+  // TODO: Optimization. Don't call clSetKernelExecInfo() if the
+  //       kernel is known not to access any buffer indirectly
+  //       discovered through kernel code inspection.
+  std::vector<void *> SvmAnnotationList;
+  std::unique_ptr<std::vector<std::shared_ptr<void>>> SvmKeepAlives;
+  LOCK(Ctx.ContextMtx); // CHIPContextOpenCL::SvmMemory
+  auto NumSvmAllocations = Ctx.SvmMemory.getNumAllocations();
+  if (NumSvmAllocations) {
+    SvmAnnotationList.reserve(NumSvmAllocations);
+    SvmKeepAlives.reset(new std::vector<std::shared_ptr<void>>());
+    SvmKeepAlives->reserve(NumSvmAllocations);
+    for (std::shared_ptr<void> Ptr : Ctx.SvmMemory.getSvmPointers()) {
+      SvmAnnotationList.push_back(Ptr.get());
+      SvmKeepAlives->push_back(Ptr);
+    }
+
+    // TODO: Optimization. Don't call this function again if we know the
+    //       SvmAnnotationList hasn't changed since the last call.
+    auto Status = clSetKernelExecInfo(
+        KernelAPIHandle, CL_KERNEL_EXEC_INFO_SVM_PTRS,
+        SvmAnnotationList.size() * sizeof(void *), SvmAnnotationList.data());
+    CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS, hipErrorTbd);
+  }
+
+  return SvmKeepAlives;
+}
+
+struct KernelEventCallbackData {
+  std::shared_ptr<CHIPArgSpillBuffer> ArgSpillBuffer;
+  std::unique_ptr<std::vector<std::shared_ptr<void>>> SvmKeepAlives;
+};
+static void CL_CALLBACK kernelEventCallback(cl_event Event,
+                                            cl_int CommandExecStatus,
+                                            void *UserData) {
+  delete static_cast<KernelEventCallbackData *>(UserData);
 }
 
 // CHIPCallbackDataLevel0
@@ -861,7 +906,7 @@ void CL_CALLBACK pfn_notify(cl_event Event, cl_int CommandExecStatus,
   delete Cbo;
 }
 
-void CHIPQueueOpenCL::MemMap(AllocationInfo *AllocInfo,
+void CHIPQueueOpenCL::MemMap(const AllocationInfo *AllocInfo,
                              CHIPQueue::MEM_MAP_TYPE Type) {
   if (static_cast<CHIPDeviceOpenCL *>(this->getDevice())
           ->supportsFineGrainSVM()) {
@@ -884,7 +929,7 @@ void CHIPQueueOpenCL::MemMap(AllocationInfo *AllocInfo,
   assert(Status == CL_SUCCESS);
 }
 
-void CHIPQueueOpenCL::MemUnmap(AllocationInfo *AllocInfo) {
+void CHIPQueueOpenCL::MemUnmap(const AllocationInfo *AllocInfo) {
   if (static_cast<CHIPDeviceOpenCL *>(this->getDevice())
           ->supportsFineGrainSVM()) {
     logDebug("Device supports fine grain SVM. Skipping MemMap/Unmap");
@@ -959,22 +1004,36 @@ CHIPEvent *CHIPQueueOpenCL::launchImpl(CHIPExecItem *ExecItem) {
 
   logTrace("Launch LOCAL: {} {} {}", Local[0], Local[1], Local[2]);
 #ifdef DUBIOUS_LOCKS
-  LOCK(Backend->DubiousLockOpenCL)
+  LOCK(Backend->DubiousLockOpenCL);
 #endif
+
+  auto SvmAllocationsToKeepAlive =
+      annotateSvmPointers(*OclContext, Kernel->get()->get());
+
   auto Status = clEnqueueNDRangeKernel(ClQueue_->get(), Kernel->get()->get(),
                                        NumDims, GlobalOffset, Global, Local, 0,
                                        nullptr, LaunchEvent->getNativePtr());
   CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS, hipErrorTbd);
 
-  if (std::shared_ptr<CHIPArgSpillBuffer> SpillBuf =
-          ExecItem->getArgSpillBuffer()) {
-    // Use an event call back to prolong the lifetime of the spill buffer
-    // in case the exec item gets destroyed before the kernel
-    // is launched/completed (may happen when called from
-    // CHIPQueue::launchKernel()).
-    auto *CBData = new decltype(SpillBuf)(SpillBuf);
+  std::shared_ptr<CHIPArgSpillBuffer> SpillBuf = ExecItem->getArgSpillBuffer();
+
+  if (SpillBuf || SvmAllocationsToKeepAlive) {
+    // Use an event call back to prolong the lifetimes of the
+    // following objects until the kernel terminates.
+    //
+    // * SpillBuffer holds an allocation referenced by the kernel
+    //   shared by exec item, which might get destroyed before the
+    //   kernel is launched/completed
+    //
+    // * Annotated SVM pointers may need to outlive the kernel
+    //   execution. The OpenCL spec does not clearly specify how long
+    //   the pointers, annotated via clSetKernelExecInfo(), needs to
+    //   live.
+    auto *CBData = new KernelEventCallbackData;
+    CBData->ArgSpillBuffer = SpillBuf;
+    CBData->SvmKeepAlives = std::move(SvmAllocationsToKeepAlive);
     Status = clSetEventCallback(LaunchEvent->getNativeRef(), CL_COMPLETE,
-                                releaseSpillBufferCallback, CBData);
+                                kernelEventCallback, CBData);
     if (Status != CL_SUCCESS) {
       delete CBData;
       CHIPERR_CHECK_LOG_AND_THROW(Status, CL_SUCCESS, hipErrorTbd);

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -51,6 +51,7 @@
 #include "../../CHIPBackend.hh"
 #include "exceptions.hh"
 #include "spirv.hh"
+#include "Utils.hh"
 
 #define OCL_DEFAULT_QUEUE_PRIORITY CL_QUEUE_PRIORITY_MED_KHR
 
@@ -126,7 +127,7 @@ class SVMemoryRegion {
   enum SVM_ALLOC_GRANULARITY { COARSE_GRAIN, FINE_GRAIN };
   // ContextMutex should be enough
 
-  std::map<void *, size_t> SvmAllocations_;
+  std::map<std::shared_ptr<void>, size_t, PointerCmp<void>> SvmAllocations_;
   cl::Context Context_;
 
 public:

--- a/src/backend/OpenCL/CHIPBackendOpenCL.hh
+++ b/src/backend/OpenCL/CHIPBackendOpenCL.hh
@@ -131,6 +131,9 @@ class SVMemoryRegion {
   cl::Context Context_;
 
 public:
+  using const_svm_alloc_iterator = ConstMapKeyIterator<
+      std::map<std::shared_ptr<void>, size_t, PointerCmp<void>>>;
+
   void init(cl::Context &C) { Context_ = C; }
   SVMemoryRegion &operator=(SVMemoryRegion &&Rhs);
   void *allocate(size_t Size, SVM_ALLOC_GRANULARITY Granularity = COARSE_GRAIN);
@@ -142,6 +145,13 @@ public:
   int memFill(void *Dst, size_t Size, const void *Pattern, size_t PatternSize,
               cl::CommandQueue &Queue);
   void clear();
+
+  size_t getNumAllocations() const { return SvmAllocations_.size(); }
+  IteratorRange<const_svm_alloc_iterator> getSvmPointers() const {
+    return IteratorRange<const_svm_alloc_iterator>(
+        const_svm_alloc_iterator(SvmAllocations_.begin()),
+        const_svm_alloc_iterator(SvmAllocations_.end()));
+  }
 };
 
 class CHIPContextOpenCL : public CHIPContext {
@@ -211,7 +221,7 @@ protected:
    * @param AllocInfo AllocationInfo object to be mapped for the host
    * @param Type Type of mapping to be performed. Either READ or WRITE
    */
-  virtual void MemMap(AllocationInfo *AllocInfo,
+  virtual void MemMap(const AllocationInfo *AllocInfo,
                       CHIPQueue::MEM_MAP_TYPE Type) override;
 
   /**
@@ -221,7 +231,7 @@ protected:
    *
    * @param AllocInfo
    */
-  virtual void MemUnmap(AllocationInfo *AllocInfo) override;
+  virtual void MemUnmap(const AllocationInfo *AllocInfo) override;
 
 public:
   CHIPQueueOpenCL() = delete; // delete default constructor

--- a/tests/fromLibCeed/firstTouch.cpp
+++ b/tests/fromLibCeed/firstTouch.cpp
@@ -13,11 +13,8 @@ int main() {
   hipLaunchKernelGGL(setOne, dim3(1), dim3(1), 0, 0, data);
   hipDeviceSynchronize();
   hipMemcpy(A_h, data.A_d, sizeof(int), hipMemcpyDeviceToHost);
-  if (A_h[0] == 1) {
-    printf("PASSED\n");
-  } else {
-    printf("FAILED\n");
-  }
+  bool Failed = A_h[0] != 1;
+  printf(Failed ? "FAILED\n" : "PASSED\n");
   hipFree(data.A_d);
-  return 0;
+  return Failed;
 }

--- a/tests/runtime/CMakeLists.txt
+++ b/tests/runtime/CMakeLists.txt
@@ -36,6 +36,9 @@ function(add_hip_runtime_test MAIN_SOURCE)
     PRIVATE $<TARGET_PROPERTY:CHIP,INCLUDE_DIRECTORIES>)
 
   add_test(NAME ${EXEC_NAME} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${EXEC_NAME})
+
+  set_tests_properties("${EXEC_NAME}" PROPERTIES
+    SKIP_REGULAR_EXPRESSION "SKIP")
 endfunction()
 
 add_hip_runtime_test(TestLazyModuleInit.cpp)
@@ -50,3 +53,4 @@ add_hip_runtime_test(TestStlFunctions.hip)
 add_hip_runtime_test(TestStlFunctionsDouble.hip)
 add_hip_runtime_test(TestHIPMathFunctions.hip)
 add_hip_runtime_test(TestAtomics.hip)
+add_hip_runtime_test(TestIndirectMappedHostAlloc.hip)

--- a/tests/runtime/TestIndirectMappedHostAlloc.hip
+++ b/tests/runtime/TestIndirectMappedHostAlloc.hip
@@ -1,0 +1,50 @@
+// Regression test for https://github.com/CHIP-SPV/chip-spv/issues/211
+#include <hip/hip_runtime_api.h>
+#include <cstdio>
+#include <cstdlib>
+
+#define HIP_CHECK(X)                                                           \
+  do {                                                                         \
+    if (X != hipSuccess)                                                       \
+      exit(2);                                                                 \
+  } while (0)
+
+struct Foo {
+  int Bar;
+  int *Data;
+};
+
+__global__ void kernel(Foo Out, const Foo In) { *Out.Data = *In.Data + In.Bar; }
+
+int main() {
+  hipDeviceProp_t Prop;
+  int Device;
+  HIP_CHECK(hipGetDevice(&Device));
+  HIP_CHECK(hipGetDeviceProperties(&Prop, Device));
+  if (!Prop.canMapHostMemory) {
+    printf("SKIP: Test requires canMapHostMemory == 1\n");
+    return 2;
+  }
+
+  int *InH, *OutH;
+  HIP_CHECK(hipHostMalloc((void **)&InH, sizeof(int), hipHostMallocMapped));
+  HIP_CHECK(hipHostMalloc((void **)&OutH, sizeof(int), hipHostMallocMapped));
+  *InH = 23;
+  *OutH = 0;
+
+  int *InD, *OutD;
+  HIP_CHECK(hipHostGetDevicePointer((void**)&InD, InH, 0));
+  HIP_CHECK(hipHostGetDevicePointer((void**)&OutD, OutH, 0));
+
+  Foo In = {100, InD}, Out = {0, OutD};
+
+  kernel<<<dim3(1), dim3(1)>>>(Out, In);
+  HIP_CHECK(hipDeviceSynchronize());
+
+  printf("*OutH = %d\n", *OutH);
+  bool Failed = *OutH != 123;
+
+  HIP_CHECK(hipHostFree(InH));
+  HIP_CHECK(hipHostFree(OutH));
+  return Failed;
+}


### PR DESCRIPTION
* Fixed RegisterdVarCopy() didn’t synchronize pinned host allocations if the pointers were passed indirectly to kernels. Fixed by synchronizing all pinned host allocations known by the runtime.
* Fixed OpenCL and Level Zero backend drivers were not informed about indirect allocations.
* Fixed a test with false positive test outcome.

Fixes #211.
Closes #386.
